### PR TITLE
Error in transmit: request() got multiple values for keyword argument 'headers'

### DIFF
--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -73,16 +73,16 @@ class FuzzerTarget(ServerTarget):
             self.logger.warn('>>> Formatted URL: {} <<<'.format(request_url))
 
 	    if "API_FUZZER_API_KEY" in os.environ:
-		headers = {'Authorization': 'api-key {}'.format(os.getenv("API_FUZZER_API_KEY", ""))}
+                headers = {'Authorization': 'api-key {}'.format(os.getenv("API_FUZZER_API_KEY", ""))}
                 if 'headers' in kwargs:
                     combinedHeaders = {key: value for (key, value) in (headers.items() + kwargs['headers'].items())}
                     del kwargs['headers']
                     headers = combinedHeaders
                 self.logger.warn('Request Headers:{}, KWARGS:{}, url: {}'.format(headers, kwargs, _req_url))
-		_return = requests.request(url=request_url, headers=headers, verify=False, **kwargs)
+                _return = requests.request(url=request_url, headers=headers, verify=False, **kwargs)
 	    else:
                 self.logger.warn('Request KWARGS:{}, url: {}'.format(kwargs, _req_url))
-		_return = requests.request(url=request_url, verify=False, **kwargs)
+                _return = requests.request(url=request_url, verify=False, **kwargs)
 
             status_code = _return.status_code
             if status_code:

--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -73,7 +73,14 @@ class FuzzerTarget(ServerTarget):
             kwargs.pop('url')
             self.logger.warn('>>> Formatted URL: {} <<<'.format(request_url))
             headers = {'Authorization': 'api-key {}'.format(os.getenv("API_FUZZER_API_KEY", ""))}
-            _return = requests.request(url=request_url, headers=headers, **kwargs)
+
+            if kwargs["headers"]:
+                combinedHeaders = {key: value for (key, value) in (headers.items() + kwargs['headers'].items())}
+                del kwargs['headers']
+                _return = requests.request(url=request_url, headers=combinedHeaders, **kwargs)
+            else:
+                _return = requests.request(url=request_url, headers=headers, **kwargs)
+
             status_code = _return.status_code
             if status_code:
                 if status_code not in self.accepted_status_codes:

--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -64,7 +64,6 @@ class FuzzerTarget(ServerTarget):
             for url_part in self.base_url, kwargs['url']:
                 self.logger.info('URL part: {}'.format(url_part))
                 _req_url.append(url_part.strip('/'))
-            self.logger.warn('Request KWARGS:{}, url: {}'.format(kwargs, _req_url))
             request_url = '/'.join(_req_url)
             request_url = self.expand_path_variables(request_url, kwargs.get('path_variables'))
             request_url = self.expand_query_parameters(request_url, kwargs.get('params'))
@@ -74,12 +73,14 @@ class FuzzerTarget(ServerTarget):
             self.logger.warn('>>> Formatted URL: {} <<<'.format(request_url))
             headers = {'Authorization': 'api-key {}'.format(os.getenv("API_FUZZER_API_KEY", ""))}
 
-            if kwargs["headers"]:
+            if 'headers' in kwargs:
                 combinedHeaders = {key: value for (key, value) in (headers.items() + kwargs['headers'].items())}
                 del kwargs['headers']
-                _return = requests.request(url=request_url, headers=combinedHeaders, **kwargs)
-            else:
-                _return = requests.request(url=request_url, headers=headers, **kwargs)
+                headers = combinedHeaders
+
+            self.logger.warn('Request Headers:{}, KWARGS:{}, url: {}'.format(headers, kwargs, _req_url))
+
+            _return = requests.request(url=request_url, headers=headers, **kwargs)
 
             status_code = _return.status_code
             if status_code:


### PR DESCRIPTION
kwargs JSON object has another header.

```
[ERROR   ][server_fuzzer._transmit] Error in transmit: request() got multiple values for keyword argument 'headers'
[ERROR   ][server._start] Error occurred while fuzzing: TypeError("request() got multiple values for keyword argument 'headers'",)
[ERROR   ][server._start] Traceback (most recent call last):
```

Because of the enhancement that was made to allow specification of the
API Key thru environmental variable as header, the side-effect is there
are two headers being sent to the requests.request() call.

To resolve the issue, we can check if header exist in kwargs JSON
object, if so then we merge both headers into a single combined header
then pass it as an input to requests.request() call.